### PR TITLE
Rebuild libgit2 against pcre2 10.46 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d25866a4ee275a64f65be2d9a663680a5cf1ed87b7ee4c534997562c828e500d
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # SONAME is based on minor version
     - {{ pin_subpackage("libgit2", max_pin="x.x") }}
@@ -20,13 +20,14 @@ requirements:
     - cmake
     - ninja
     - pkg-config      # [not win]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - msinttypes r26  # [win]
     - openssl {{ openssl }}  # [linux]
     - libiconv 1.16  # [osx]
-    - pcre2 10.42  # [unix]
+    - pcre2 {{ pcre2 }} # [unix]
     - curl 7.88.1
     - libssh2 1.10.0
     - zlib {{ zlib }}
@@ -162,20 +163,18 @@ test:
     {% endfor %}
 
 about:
-  home: https://libgit2.org/
+  home: https://libgit2.org
   license: GPL-2.0-only WITH GCC-exception-2.0
   license_file: COPYING
   license_family: GPL2
-  summary: 'libgit2 is a portable, pure C implementation of the Git core methods provided as a re-entrant linkable library with a solid API, allowing you to write native speed custom Git applications in any language which supports C bindings.'
-
-  # The remaining entries in this section are optional, but recommended
+  summary: A cross-platform, linkable library implementation of Git that you can use in your application.
   description: |
     libgit2 is a portable, pure C implementation of the Git core methods
     provided as a re-entrant linkable library with a solid API, allowing
     you to write native speed custom Git applications in any language
     which supports C bindings.
   dev_url: https://github.com/libgit2/libgit2
-  doc_url: https://libgit2.org/docs/
+  doc_url: https://libgit2.org/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
libgit2 1.6.4

**Destination channel:** Defaults

### Links

- [PKG-10076](https://anaconda.atlassian.net/browse/PKG-10076)
- [Upstream repository](https://github.com/libgit2/libgit2/tree/v1.6.4)

### Explanation of changes:

- Increase build number
- Satisfy linter
- Add cbc pinning to pcre2


[PKG-10076]: https://anaconda.atlassian.net/browse/PKG-10076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ